### PR TITLE
Add option to URL encode SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ _Load the raw SVG data using `raw-loader`. Useful if anything in the SVG needs t
 </script>
 ```
 
+### utf-8 encoded DataUrl String
+
+_URL encoded SVG using `svg-url-loader` for use in CSS_
+
+```html
+<template>
+  <div :style="inlineStyle" />
+</template>
+
+<script>
+  export default {
+    data () {
+      return {
+        inlineStyle: {
+          width: '556px',
+          height: '96px',
+          background: `url("${require('~/assets/nuxt.svg?url')}") no-repeat`,
+          backgroundSize: 'cover'
+        }
+      }
+    }
+  };
+</script>
+```
+
 ## Caveats
 
 In order for this module to work correctly, the [default `.svg` Nuxt.js webpack rule](https://nuxtjs.org/guide/assets/#webpack) gets replaced with this handler.

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -11,6 +11,9 @@
 
     <h3>Inline Raw</h3>
     <div v-html="rawSvg" />
+
+    <h3>Inline URL:</h3>
+    <div :style="inlineStyle" />
   </div>
 </template>
 
@@ -25,7 +28,13 @@ export default {
 
   data () {
     return {
-      rawSvg: NuxtLogoRaw
+      rawSvg: NuxtLogoRaw,
+      inlineStyle: {
+        width: '556px',
+        height: '96px',
+        background: `url("${require('~/assets/nuxt.svg?url')}") no-repeat`,
+        backgroundSize: 'cover'
+      }
     }
   }
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -64,6 +64,10 @@ function setup (config) {
         loader: 'raw-loader'
       },
       {
+        resourceQuery: /url/,
+        loader: 'svg-url-loader'
+      },
+      {
         loader: 'file-loader' // By default, always use file-loader
       }
     ]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "file-loader": "^4.0.0",
     "raw-loader": "^3.1.0",
+    "svg-url-loader": "^3.0.2",
     "url-loader": "^2.0.0",
     "vue-svg-loader": "^0.12.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9184,6 +9184,14 @@ svg-to-vue@^0.4.0:
   dependencies:
     svgo "^1.1.1"
 
+svg-url-loader@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/svg-url-loader/-/svg-url-loader-3.0.2.tgz#7bcbb676927e71c9267fd879f8962396b59aa04a"
+  integrity sha512-MUJFVU2uuOTZW6Eq6NuXZxhaIyWiuKtZMcT90nCkcvIZPGGc0CYyZWYP/rtXUkja5qagNMpxDwdZ/tuC6ywfWg==
+  dependencies:
+    file-loader "~4.2.0"
+    loader-utils "~1.2.3"
+
 svgo@^1.0.0, svgo@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.0.tgz#bae51ba95ded9a33a36b7c46ce9c359ae9154313"


### PR DESCRIPTION
Use webpack's `svg-url-loader` to load SVGs as a utf-8 DataURL string. Useful when using SVGs in CSS.