### PR TITLE
Add raw SVG loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ _Inline as an actual svg element using `vue-svg-loader`_
 <svg xmlns="http://www.w3.org/2000/svg"><path></path></svg>
 ```
 
+### Raw SVG loader
+
+_Load the raw SVG data using `raw-loader`. Useful if anything in the SVG needs to be modified_
+
+
+```html
+<template>
+  <div v-html="rawSvg" />
+</template>
+
+<script>
+  import nuxtLogoRaw from '~/assets/nuxt.svg?raw'
+
+  export default {
+    data () {
+      return {
+        rawSvg: nuxtLogoRaw
+      }
+    }
+  };
+</script>
+```
+
+
 ## Caveats
 
 In order for this module to work correctly, the [default `.svg` Nuxt.js webpack rule](https://nuxtjs.org/guide/assets/#webpack) gets replaced with this handler.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ _Load the raw SVG data using `raw-loader`. Useful if anything in the SVG needs t
 </script>
 ```
 
-
 ## Caveats
 
 In order for this module to work correctly, the [default `.svg` Nuxt.js webpack rule](https://nuxtjs.org/guide/assets/#webpack) gets replaced with this handler.

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -20,4 +20,3 @@ export default {
   }
 }
 </script>
-</script>

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -8,15 +8,25 @@
 
     <h3>Inline Components:</h3>
     <NuxtLogo />
+
+    <h3>Inline Raw</h3>
+    <div v-html="rawSvg" />
   </div>
 </template>
 
 <script>
 import NuxtLogo from '~/assets/nuxt.svg?inline'
+import nuxtLogoRaw from '~/assets/nuxt.svg?raw'
 
 export default {
   components: {
     NuxtLogo
+  },
+
+  data () {
+    return {
+      rawSvg: nuxtLogoRaw
+    }
   }
 }
 </script>

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -16,7 +16,7 @@
 
 <script>
 import NuxtLogo from '~/assets/nuxt.svg?inline'
-import nuxtLogoRaw from '~/assets/nuxt.svg?raw'
+import NuxtLogoRaw from '~/assets/nuxt.svg?raw'
 
 export default {
   components: {
@@ -25,7 +25,7 @@ export default {
 
   data () {
     return {
-      rawSvg: nuxtLogoRaw
+      rawSvg: NuxtLogoRaw
     }
   }
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -60,6 +60,10 @@ function setup (config) {
         loader: 'url-loader'
       },
       {
+        resourceQuery: /raw/,
+        loader: 'raw-loader'
+      },
+      {
         loader: 'file-loader' // By default, always use file-loader
       }
     ]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "file-loader": "^4.0.0",
+    "raw-loader": "^3.1.0",
     "url-loader": "^2.0.0",
     "vue-svg-loader": "^0.12.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4139,7 +4139,7 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@^4.0.0, file-loader@^4.2.0:
+file-loader@^4.0.0, file-loader@^4.2.0, file-loader@~4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.2.0.tgz#5fb124d2369d7075d70a9a5abecd12e60a95215e"
   integrity sha512-+xZnaK5R8kBJrHK0/6HRlrKNamvVS5rjyuju+rnyxRGuwUJwpAMsVzUl5dz6rK8brkzjV6JpcFNjp6NqV0g1OQ==
@@ -5958,7 +5958,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -8087,6 +8087,14 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-3.1.0.tgz#5e9d399a5a222cc0de18f42c3bc5e49677532b3f"
+  integrity sha512-lzUVMuJ06HF4rYveaz9Tv0WRlUMxJ0Y1hgSkkgg+50iEdaI0TthyEDe08KIHb0XsF6rn8WYTqPCaGTZg3sX+qA==
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^2.0.1"
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -8568,6 +8576,14 @@ schema-utils@^2.0.0:
   dependencies:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
+
+schema-utils@^2.0.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.5.0.tgz#8f254f618d402cc80257486213c8970edfd7c22f"
+  integrity sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==
+  dependencies:
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
 
 scriptjs@^2.5.9:
   version "2.5.9"


### PR DESCRIPTION
Add the ability to import SVG as raw data using webpack's `raw-loader`. Useful if you need to manipulate the SVG before adding it to the DOM.