### PR TITLE
fix(edge): apply bable-loader on modern builds too

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -41,7 +41,7 @@ function setup (config) {
     }
   ]
 
-  if (config.name === 'client') {
+  if (config.name !== 'server') {
     const jsxRule = config.module.rules.find(r => r.test.test('.jsx'))
     const babelLoader = jsxRule.use[jsxRule.use.length - 1]
     vueSvgLoader.unshift(babelLoader)


### PR DESCRIPTION
Due to MS Edge uses modern build, but does not properly work with the rest operator used in the [svg-to-vue](https://github.com/visualfanatic/svg-to-vue) package, the current version of this package does not work in MS Edge out of the box. By applying bable-loader on modern builds too, this issue could be solved. This would also fix https://github.com/nuxt-community/svg-module/issues/11. 