### PR TITLE
Use "buildModules" instead of "modules"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install --save-dev @nuxtjs/svg
 ```javascript
 // nuxt.config.js
 export default {
-  modules: ["@nuxtjs/svg"],
+  buildModules: ["@nuxtjs/svg"],
 };
 ```
 


### PR DESCRIPTION
This module only extends build configuration so no need to use
it in production. Instructions even say to install it as dev dependency
so it would even cause a crash in production as it would be missing.