### PR TITLE
Fix: use explicit loader resolution

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -38,7 +38,7 @@ function setup(config) {
 
   const vueSvgLoader = [
     {
-      loader: "vue-svg-loader",
+      loader: require.resolve("vue-svg-loader"),
       options: { svgo: false },
     },
   ];
@@ -63,20 +63,20 @@ function setup(config) {
       {
         resourceQuery: /data/,
         use: {
-          loader: "url-loader",
+          loader: require.resolve("url-loader"),
           options: { esModule: false },
         },
       },
       {
         resourceQuery: /raw/,
         use: {
-          loader: "raw-loader",
+          loader: require.resolve("raw-loader"),
           options: { esModule: false },
         },
       },
       {
         use: {
-          loader: "file-loader",
+          loader: require.resolve("file-loader"),
           options: { esModule: false },
         },
       },


### PR DESCRIPTION
#### My env:

- `@nuxtjs/svg@0.1.12`
- `nuxt@2.14.6`

#### Issue:

`vue-svg-loader` is installed under `node_modules/@nuxtjs/svg/node_modules/vue-svg-loader` and for some reason webpack is not resolving its path correctly throwing an error:

```
Module not found: Error: Can't resolve 'vue-svg-loader'
```

#### Solution 

This PR, by using `require.resolve`, should instruct webpack on the correct loaders' paths. 