### PR TITLE
fix: pass the correct context parameters to the file-loader

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -20,13 +20,14 @@ export default function svgModule(moduleOptions) {
  *
  * @param options The module options
  * @param config The webpack configuration object to extend
+ * @param context Nuxt webpack env
  */
-function setup(options, config) {
+function setup(options, config, context) {
   const fileLoaderOptions = Object.assign(
     {},
-    getFileLoaderDefaultConfig(this),
+    getFileLoaderDefaultConfig(context),
     typeof options.fileLoader === "function"
-      ? options.fileLoader(this)
+      ? options.fileLoader(context)
       : options.fileLoader
   );
 


### PR DESCRIPTION
File loader should get `{ isDev }` from `this.extendBuild`.

----
@nuxtjs/svg: 0.4.0
Nuxt: 2.17.1
